### PR TITLE
Fixes #1

### DIFF
--- a/src/widgets/qxtglobalshortcut_p.h
+++ b/src/widgets/qxtglobalshortcut_p.h
@@ -40,12 +40,19 @@
 #include <QAbstractNativeEventFilter>
 #endif
 
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0) && !defined(Q_OS_MAC)
+class GlobalShortcutEventFilter : public QAbstractNativeEventFilter {
+public:
+    virtual bool nativeEventFilter(const QByteArray & eventType, void * message, long * result);
+static GlobalShortcutEventFilter* filterinst;
+};
+
+#endif
+
 
 class QxtGlobalShortcutPrivate : public QxtPrivate<QxtGlobalShortcut>
-#if QT_VERSION >= QT_VERSION_CHECK(5,0,0) && !defined(Q_OS_MAC)
-        ,public QAbstractNativeEventFilter
-#endif
 {
+
 public:
     QXT_DECLARE_PUBLIC(QxtGlobalShortcut)
     QxtGlobalShortcutPrivate();
@@ -64,8 +71,6 @@ public:
 #if QT_VERSION < QT_VERSION_CHECK(5,0,0)
     static QAbstractEventDispatcher::EventFilter prevEventFilter;
     static bool eventFilter(void* message);
-#else
-    virtual bool nativeEventFilter(const QByteArray & eventType, void * message, long * result);
 #endif // QT_VERSION < QT_VERSION_CHECK(5,0,0)
 #endif // Q_OS_MAC
 

--- a/src/widgets/win/qxtglobalshortcut_win.cpp
+++ b/src/widgets/win/qxtglobalshortcut_win.cpp
@@ -36,7 +36,7 @@
 bool QxtGlobalShortcutPrivate::eventFilter(void* message)
 {
 #else
-bool QxtGlobalShortcutPrivate::nativeEventFilter(const QByteArray & eventType,
+bool GlobalShortcutEventFilter::nativeEventFilter(const QByteArray & eventType,
     void * message, long * result)
 {
     Q_UNUSED(eventType);
@@ -47,7 +47,7 @@ bool QxtGlobalShortcutPrivate::nativeEventFilter(const QByteArray & eventType,
     {
         const quint32 keycode = HIWORD(msg->lParam);
         const quint32 modifiers = LOWORD(msg->lParam);
-        activateShortcut(keycode, modifiers);
+        QxtGlobalShortcutPrivate::activateShortcut(keycode, modifiers);
     }
 
 #if QT_VERSION < QT_VERSION_CHECK(5,0,0)

--- a/src/widgets/x11/qxtglobalshortcut_x11.cpp
+++ b/src/widgets/x11/qxtglobalshortcut_x11.cpp
@@ -150,7 +150,7 @@ bool QxtGlobalShortcutPrivate::eventFilter(void *message)
         unsigned int keycode = key->keycode;
         unsigned int keystate = key->state;
 #else
-bool QxtGlobalShortcutPrivate::nativeEventFilter(const QByteArray & eventType,
+bool GlobalShortcutEventFilter::nativeEventFilter(const QByteArray & eventType,
     void *message, long *result)
 {
     Q_UNUSED(result);
@@ -174,7 +174,7 @@ bool QxtGlobalShortcutPrivate::nativeEventFilter(const QByteArray & eventType,
         if(kev->state & XCB_MOD_MASK_SHIFT)
             keystate |= ShiftMask;
 #endif
-        activateShortcut(keycode,
+        QxtGlobalShortcutPrivate::activateShortcut(keycode,
             // Mod1Mask == Alt, Mod4Mask == Meta
             keystate & (ShiftMask | ControlMask | Mod1Mask | Mod4Mask));
     }


### PR DESCRIPTION
I have made the event handler a seperated singleton class.

I have tested it on linux.
I have fixed it for windows, but not tested it.
It should be fine for mac because its implementation is a bit different. (but also not tested)

Here is my test application:
https://github.com/mrbesen/qxtglobalshortcutTest

Before fix:
```
$ ./testApp 
qt5ct: using qt5ct plugin
qt5ct: D-Bus global menu: no
Testshortcut 1
Testshortcut 2
delete1
```
(After delete1 no shortcuts are captured)

After fix:
```
$ ./testApp 
qt5ct: using qt5ct plugin
qt5ct: D-Bus global menu: no
Testshortcut 1
Testshortcut 2
delete1
Testshortcut 2

```
(After delete1 only shortcut2 is captured, because shortcut1 was deleted)