### PR TITLE
Numpad support for linux

### DIFF
--- a/src/widgets/mac/qxtglobalshortcut_mac.cpp
+++ b/src/widgets/mac/qxtglobalshortcut_mac.cpp
@@ -71,7 +71,7 @@ quint32 QxtGlobalShortcutPrivate::nativeModifiers(Qt::KeyboardModifiers modifier
     return native;
 }
 
-quint32 QxtGlobalShortcutPrivate::nativeKeycode(Qt::Key key)
+quint32 QxtGlobalShortcutPrivate::nativeKeycode(Qt::Key key, Qt::KeyboardModifiers /* modifiers */ )
 {
     UTF16Char ch;
     // Constants found in NSEvent.h from AppKit.framework

--- a/src/widgets/qxtglobalshortcut.cpp
+++ b/src/widgets/qxtglobalshortcut.cpp
@@ -82,7 +82,7 @@ QxtGlobalShortcutPrivate::~QxtGlobalShortcutPrivate()
 bool QxtGlobalShortcutPrivate::setShortcut(const QKeySequence& shortcut)
 {
     Qt::KeyboardModifiers allMods = Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier | Qt::KeypadModifier;
-    key = shortcut.isEmpty() ? Qt::Key(0) : Qt::Key((shortcut[0] ^ allMods) & shortcut[0]);
+    key = shortcut.isEmpty() ? Qt::Key(0) : Qt::Key(shortcut[0] & (~allMods));
     mods = shortcut.isEmpty() ? Qt::KeyboardModifiers(0) : Qt::KeyboardModifiers(shortcut[0] & allMods);
     nativeKey = nativeKeycode(key, mods);
     nativeMods = nativeModifiers(mods);

--- a/src/widgets/qxtglobalshortcut.cpp
+++ b/src/widgets/qxtglobalshortcut.cpp
@@ -81,11 +81,11 @@ QxtGlobalShortcutPrivate::~QxtGlobalShortcutPrivate()
 
 bool QxtGlobalShortcutPrivate::setShortcut(const QKeySequence& shortcut)
 {
-    Qt::KeyboardModifiers allMods = Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier;
+    Qt::KeyboardModifiers allMods = Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier | Qt::KeypadModifier;
     key = shortcut.isEmpty() ? Qt::Key(0) : Qt::Key((shortcut[0] ^ allMods) & shortcut[0]);
     mods = shortcut.isEmpty() ? Qt::KeyboardModifiers(0) : Qt::KeyboardModifiers(shortcut[0] & allMods);
-    const quint32 nativeKey = nativeKeycode(key);
-    const quint32 nativeMods = nativeModifiers(mods);
+    nativeKey = nativeKeycode(key, mods);
+    nativeMods = nativeModifiers(mods);
     const bool res = registerShortcut(nativeKey, nativeMods);
     if (res)
         shortcuts.insert(qMakePair(nativeKey, nativeMods), &qxt_p());
@@ -97,8 +97,6 @@ bool QxtGlobalShortcutPrivate::setShortcut(const QKeySequence& shortcut)
 bool QxtGlobalShortcutPrivate::unsetShortcut()
 {
     bool res = false;
-    const quint32 nativeKey = nativeKeycode(key);
-    const quint32 nativeMods = nativeModifiers(mods);
     if (shortcuts.value(qMakePair(nativeKey, nativeMods)) == &qxt_p())
         res = unregisterShortcut(nativeKey, nativeMods);
     if (res)

--- a/src/widgets/qxtglobalshortcut_p.h
+++ b/src/widgets/qxtglobalshortcut_p.h
@@ -61,6 +61,8 @@ public:
     bool enabled;
     Qt::Key key;
     Qt::KeyboardModifiers mods;
+    quint32 nativeKey;
+    quint32 nativeMods;
 
     bool setShortcut(const QKeySequence& shortcut);
     bool unsetShortcut();
@@ -77,7 +79,7 @@ public:
     static void activateShortcut(quint32 nativeKey, quint32 nativeMods);
 
 private:
-    static quint32 nativeKeycode(Qt::Key keycode);
+    static quint32 nativeKeycode(Qt::Key keycode, Qt::KeyboardModifiers modifiers);
     static quint32 nativeModifiers(Qt::KeyboardModifiers modifiers);
 
     static bool registerShortcut(quint32 nativeKey, quint32 nativeMods);

--- a/src/widgets/win/qxtglobalshortcut_win.cpp
+++ b/src/widgets/win/qxtglobalshortcut_win.cpp
@@ -76,7 +76,7 @@ quint32 QxtGlobalShortcutPrivate::nativeModifiers(Qt::KeyboardModifiers modifier
     return native;
 }
 
-quint32 QxtGlobalShortcutPrivate::nativeKeycode(Qt::Key key)
+quint32 QxtGlobalShortcutPrivate::nativeKeycode(Qt::Key key, Qt::KeyboardModifiers /* modifiers */ )
 {
     switch (key)
     {


### PR DESCRIPTION
```
shortcut1 = new QxtGlobalShortcut(QKeySequence("Shift+Num+1"));
shortcut2 = new QxtGlobalShortcut(QKeySequence("Shift+Num+,"));
shortcut3 = new QxtGlobalShortcut(QKeySequence("Shift+Num+Enter"));
shortcut4 = new QxtGlobalShortcut(QKeySequence("Shift+Num+*"));
```

are now possible on Linux too.